### PR TITLE
Oc 42 refactor base container

### DIFF
--- a/frontend/components/base/BaseContainer.test.ts
+++ b/frontend/components/base/BaseContainer.test.ts
@@ -22,10 +22,10 @@ describe('Base container', () => {
     expect(wrapper.attributes().class).toContain('container--color')
   })
 
-  test('can have a class to make columns felxibel', () => {
+  test('always contains a container__inner div', () => {
     wrapper = shallowMount(BaseContainer, {
-      propsData: { containerType: 'narrow', flexCol: true },
+      propsData: {},
     })
-    expect(wrapper.attributes().class).toContain('flex-col')
+    expect(wrapper.find('.container__inner').exists()).toBe(true)
   })
 })

--- a/frontend/components/base/BaseContainer.vue
+++ b/frontend/components/base/BaseContainer.vue
@@ -28,26 +28,18 @@ export default defineComponent({
 .container {
   display: flex;
   justify-content: center;
-  padding: 5rem;
-
-  @include respond(tab-landscape) {
-    padding: 3rem;
-  }
-  @include respond(tab-portrait) {
-    padding: 2rem;
-  }
-  @include respond(phone) {
-    padding: 1rem;
-  }
-  @include respond(tiny) {
-    padding: 0.5rem;
-  }
+  padding: 5rem 0;
 
   &__inner {
     max-width: $desktop-max-width;
-    margin: 0 auto;
-  }
+    width: 80%;
+    display: flex;
+    flex-direction: column;
 
+    @include respond(tab-portrait) {
+      width: 90%;
+    }
+  }
   &--narrow > .container__inner {
     max-width: $desktop-half-width;
   }

--- a/frontend/components/base/BaseContainer.vue
+++ b/frontend/components/base/BaseContainer.vue
@@ -1,19 +1,11 @@
 <template>
-  <section v-if="containerType === 'color'" class="container container--color">
-    <div class="container__inner" :class="{ 'flex-col': flexCol }">
-      <slot> BASECONTAINER </slot>
-    </div>
-  </section>
-
   <section
     class="container"
-    :class="[
-      containerType ? `container--${containerType}` : '',
-      flexCol ? 'flex-col' : '',
-    ]"
-    v-else
+    :class="[containerType ? `container--${containerType}` : '']"
   >
-    <slot> BASECONTAINER </slot>
+    <div class="container__inner">
+      <slot />
+    </div>
   </section>
 </template>
 
@@ -28,12 +20,7 @@ export default defineComponent({
         return ['color', 'narrow'].includes(value)
       },
     },
-    flexCol: {
-      type: Boolean,
-      default: false,
-    },
   },
-  setup() {},
 })
 </script>
 
@@ -41,9 +28,8 @@ export default defineComponent({
 .container {
   display: flex;
   justify-content: center;
-  max-width: $desktop-max-width;
-  margin: 0 auto;
   padding: 5rem;
+  width: 100%;
 
   @include respond(tab-landscape) {
     padding: 3rem;
@@ -58,36 +44,17 @@ export default defineComponent({
     padding: 0.5rem;
   }
 
-  &--color {
-    max-width: none;
-    width: 100%;
-    background-color: $discovery-blue-4;
-    padding: 0;
-  }
-
   &__inner {
     max-width: $desktop-max-width;
-    padding: 5rem;
-    @include respond(tiny) {
-      padding: 3rem;
-    }
+    margin: 0 auto;
   }
 
-  &--narrow {
+  &--narrow > .container__inner {
     max-width: $desktop-half-width;
-    padding: 3rem;
-    @include respond(tab-portrait) {
-      padding: 2rem;
-    }
-    @include respond(phone) {
-      padding: 1rem;
-    }
-    @include respond(tiny) {
-      padding: 0.5rem;
-    }
   }
-}
-.flex-col {
-  flex-direction: column;
+
+  &--color {
+    background-color: $discovery-blue-4;
+  }
 }
 </style>

--- a/frontend/components/base/BaseContainer.vue
+++ b/frontend/components/base/BaseContainer.vue
@@ -29,7 +29,6 @@ export default defineComponent({
   display: flex;
   justify-content: center;
   padding: 5rem;
-  width: 100%;
 
   @include respond(tab-landscape) {
     padding: 3rem;

--- a/frontend/components/layout/TheFooter.vue
+++ b/frontend/components/layout/TheFooter.vue
@@ -73,6 +73,7 @@ export default defineComponent({
   display: flex;
   flex-grow: 1;
   justify-content: center;
+
   a {
     text-decoration: none;
     color: $gray-darkest;
@@ -126,6 +127,7 @@ export default defineComponent({
   .footer__logo {
     display: none;
   }
+
   .footer__content {
     flex-direction: column;
   }

--- a/frontend/components/layout/TheFooter.vue
+++ b/frontend/components/layout/TheFooter.vue
@@ -32,11 +32,10 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, useStore } from '@nuxtjs/composition-api'
+import { defineComponent } from '@nuxtjs/composition-api'
 
 export default defineComponent({
   setup() {
-    const store = useStore()
     const links = [
       {
         name: 'Proclaimer',

--- a/frontend/components/layout/TheHeader.vue
+++ b/frontend/components/layout/TheHeader.vue
@@ -58,6 +58,7 @@ import LoginBox from '../global/LoginBox.vue'
 
 export default defineComponent({
   components: { LoginBox },
+
   setup() {
     function resizeHandler() {
       let resizeInterval
@@ -67,6 +68,7 @@ export default defineComponent({
         clearInterval(resizeInterval)
       }
     }
+
     function closeMobileMenuOnResize() {
       if (window.innerWidth >= 872) {
         isHeaderMobileMenuActive.value = false
@@ -99,11 +101,13 @@ export default defineComponent({
         to: '/contact',
       },
     ]
+
     const isHeaderMobileMenuActive = ref(false)
 
     function openMobileNavMenu() {
       isHeaderMobileMenuActive.value = true
     }
+
     function closeMobileNavMenu() {
       isHeaderMobileMenuActive.value = false
     }
@@ -155,9 +159,11 @@ export default defineComponent({
 .nav-links__item {
   text-decoration: none;
   position: relative;
+
   &:not(:last-child) {
     margin-right: 2.5rem;
   }
+
   &:link,
   &:visited {
     color: $gray-darkest;
@@ -225,9 +231,11 @@ export default defineComponent({
   .nav-links--desktop {
     display: none;
   }
+
   .nav-links--desktop + .login-box {
     display: none;
   }
+
   .header__mobile-menu-button {
     display: flex;
   }

--- a/frontend/pages/contact.vue
+++ b/frontend/pages/contact.vue
@@ -1,14 +1,13 @@
 <template>
   <BasePageLayout>
-    <BaseContainer containerType="narrow" :flexCol="true">
-      <div class="contact__content">
-        <h2>Get in touch</h2>
-        <p>
-          Have you got questions about this project? Ask them in the form below.
-          We’d love to get your feature requests! We always appreciate
-          constructive feedback as well.
-        </p>
-      </div>
+    <BaseContainer containerType="narrow">
+      <h2 class="contact__title">Get in touch</h2>
+      <p class="contact__paragraph">
+        Have you got questions about this project? Ask them in the form below.
+        We’d love to get your feature requests! We always appreciate
+        constructive feedback as well.
+      </p>
+
       <BaseForm @submit="sendMessage">
         <template v-slot:form>
           <p class="form__heading">Let's talk</p>
@@ -30,7 +29,7 @@
           <input class="form__input" type="text" name="email" v-model="email" />
           <label class="form__label" for="message">Message*</label>
           <textarea
-            class="form__input"
+            class="form__input contact__textarea"
             type="text"
             name="message"
             required
@@ -92,28 +91,31 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.contact__content {
-  margin-bottom: 2rem;
-  h2 {
+.contact {
+  &__title {
     margin-bottom: 1rem;
   }
+
+  &__paragraph {
+    margin-bottom: 2rem;
+  }
 }
-.container--narrow {
-  flex-direction: column;
-}
-textarea {
+
+.contact__textarea {
   resize: vertical;
 }
+
 .contact__accept {
   display: flex;
+
   input {
     margin-right: 1rem;
     position: relative;
     top: 0.2rem;
   }
 }
+
 .contact__submit-button {
-  display: block;
   margin-top: 2rem;
 }
 </style>

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -69,12 +69,8 @@
 
 <script lang="ts">
 import { defineComponent } from '@nuxtjs/composition-api'
-import BaseButton from '~/components/base/BaseButton.vue'
-import BaseContainer from '~/components/base/BaseContainer.vue'
-import BasePageLayout from '~/components/base/BasePageLayout.vue'
 
 export default defineComponent({
-  components: { BaseButton, BaseContainer, BasePageLayout },
   setup() {
     const coreValues = [
       {
@@ -136,6 +132,7 @@ export default defineComponent({
     }
   }
 }
+
 .mission {
   margin-top: 1rem;
 
@@ -166,6 +163,7 @@ export default defineComponent({
 .discord {
   &__container {
     display: flex;
+    flex-direction: row;
   }
 
   &__title {
@@ -180,10 +178,12 @@ export default defineComponent({
   }
 
   @include respond(tab-portrait) {
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    text-align: center;
+    &__container {
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+    }
 
     &__text {
       padding-bottom: 2rem;

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -40,27 +40,29 @@
       </div>
     </BaseContainer>
     <BaseContainer class="discord">
-      <div class="discord__text">
-        <h2 class="discord__title">Join Our Discord Community</h2>
-        <p class="discord__paragraph">
-          Feel free to join our Discord Community. For everyone interested in
-          contributing to open-source Feel free to join our Discord Community.
-          For everyone interested in contributing to open-source Feel free to
-          join our Discord Community. For everyone interested in contributing to
-          open-source Feel free to join our Discord Community. For everyone
-          interested in contributing to open-source Feel free to join our
-          Discord Community. For everyone interested in contributing to
-          open-source
-        </p>
+      <div class="discord__container">
+        <div class="discord__text">
+          <h2 class="discord__title">Join Our Discord Community</h2>
+          <p class="discord__paragraph">
+            Feel free to join our Discord Community. For everyone interested in
+            contributing to open-source Feel free to join our Discord Community.
+            For everyone interested in contributing to open-source Feel free to
+            join our Discord Community. For everyone interested in contributing
+            to open-source Feel free to join our Discord Community. For everyone
+            interested in contributing to open-source Feel free to join our
+            Discord Community. For everyone interested in contributing to
+            open-source
+          </p>
+        </div>
+        <iframe
+          src="https://discordapp.com/widget?id=845429016798035999&theme=dark"
+          width="350"
+          height="500"
+          allowtransparency="true"
+          frameborder="0"
+          sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"
+        ></iframe>
       </div>
-      <iframe
-        src="https://discordapp.com/widget?id=845429016798035999&theme=dark"
-        width="350"
-        height="500"
-        allowtransparency="true"
-        frameborder="0"
-        sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"
-      ></iframe>
     </BaseContainer>
   </BasePageLayout>
 </template>
@@ -135,9 +137,8 @@ export default defineComponent({
   }
 }
 .mission {
-  display: flex;
-  flex-direction: column;
   margin-top: 1rem;
+
   &__heading {
     text-align: center;
     margin-bottom: 2rem;
@@ -158,22 +159,30 @@ export default defineComponent({
 }
 
 .discord {
+  &__container {
+    display: flex;
+  }
+
   &__title {
     margin-bottom: 2rem;
     margin-right: 1rem;
   }
+
   &__text {
     .discord__paragraph {
       width: 80%;
     }
   }
+
   @include respond(tab-portrait) {
     flex-direction: column;
     justify-content: center;
     align-items: center;
     text-align: center;
+
     &__text {
       padding-bottom: 2rem;
+
       .discord__paragraph {
         margin: 0 auto 1rem;
         text-align: left;
@@ -181,9 +190,11 @@ export default defineComponent({
       }
     }
   }
+
   @include respond(phone) {
     padding: 3rem 0.5rem;
     margin: 0;
+
     iframe {
       width: 18.75rem;
     }

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -1,9 +1,8 @@
 <template>
   <BasePageLayout>
     <BaseContainer containerType="narrow">
-      <div class="login__content">
-        <h2>Login</h2>
-      </div>
+      <h2 class="login__title">Login</h2>
+
       <BaseForm @submit="loginUser">
         <template v-slot:socials>
           <LoginSocials divider-text="Or login with email" />
@@ -132,13 +131,9 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.login__content {
-  margin-bottom: 2rem;
-  h2 {
-    margin-bottom: 1rem;
+.login {
+  &__title {
+    margin-bottom: 2rem;
   }
-}
-.container--narrow {
-  flex-direction: column;
 }
 </style>

--- a/frontend/pages/signup.vue
+++ b/frontend/pages/signup.vue
@@ -1,9 +1,7 @@
 <template>
   <BasePageLayout>
     <BaseContainer containerType="narrow">
-      <div class="signup__content">
-        <h2 class="signup__title">Signup</h2>
-      </div>
+      <h2 class="signup__title">Signup</h2>
       <BaseForm @submit="registerUser">
         <template v-slot:socials>
           <LoginSocials divider-text="Or signup with email" />
@@ -152,13 +150,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.signup__content {
+.signup__title {
   margin-bottom: 2rem;
-  .signup__title {
-    margin-bottom: 1rem;
-  }
-}
-.container--narrow {
-  flex-direction: column;
 }
 </style>


### PR DESCRIPTION
With this PR, the BaseContainer gets an inner container at all times.

We use this inner container to center the content of the page. We also get the same width for all the containers of the same class, regardless of the width of the content.

This inner container has a flex layout with direction `column` by default.

Its elements are aligned to the left by default. To get centered headers (on the homepage for instance), we can use a simple `text-align: center`.

To have content inside the inner container next to each other, we need another div, like for the discord section on the home page.